### PR TITLE
optimize and speedup checking for updates

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,8 +2,8 @@ import json
 import logging
 import platform
 import subprocess
-from typing import Dict, List, Optional
 from dataclasses import dataclass
+from typing import Dict, List, Optional
 
 logging.basicConfig(filename="/tmp/flatpak_updater.log",
                     format='[FlatpakUpdater] %(asctime)s %(levelname)s %(message)s',
@@ -18,22 +18,12 @@ logger.setLevel(logging.INFO)
 class FlatpakInfo:
     name: str
     appID: str
-    localHash:  str
-    remoteHash: str
-    remote: str
-    ref: str
-    updateAvailable: bool
 
     def toJSON(self):
         return json.dumps(
             {
                 "name": self.name,
-                "appID": self.appID,
-                "localHash": self.localHash,
-                "remoteHash": self.remoteHash,
-                "remote": self.remote,
-                "ref": self.ref,
-                "updateAvailable": self.updateAvailable
+                "appID": self.appID
             },
             sort_keys=True,
             indent=4)
@@ -48,28 +38,21 @@ class Plugin:
         for k, v in self.flatpaks.items():
             res[k] = {
                 "name": v.name,
-                "appID": v.appID,
-                "localHash": v.localHash,
-                "remoteHash": v.remoteHash,
-                "remote": v.remote,
-                "ref": v.ref,
-                "updateAvailable": v.updateAvailable
+                "appID": v.appID
             }
 
         return res
 
     async def getUpdatableFlatpaks(self) -> List[str]:
         self.flatpaks.clear()
-        refs = self._getInstalledFlatpakRefs()
-        names = self._getInstalledFlatpakNames()
-        for _, (ref, name) in enumerate(zip(refs, names)):
-            logger.info(f'Getting info for {name}[{ref}]')
-            info = self._getFlatpakInfo(ref, name)
+        paks = await self._getInstalledFlatpaksWithUpdates()
+        for pak in paks:
+            logger.info(f'Getting info for {pak}')
+            name, ref = pak.split('\t')
+            info = FlatpakInfo(name=name, appID=ref)
             data = info.toJSON()
             logger.info(f'{data}')
-            if info.updateAvailable:
-                logger.info(f'Update available for {ref}, adding to dict')
-                self.flatpaks[ref] = info
+            self.flatpaks[ref] = info
 
         return self.serializeFlatpaks(self)
 
@@ -81,6 +64,7 @@ class Plugin:
         user = self._whoAmI()
         logger.info(
             f"Plugin loaded with python version {platform.python_version()} as {user}")
+
         pass
 
     # Function called first during the unload process, utilize this to handle your plugin being removed
@@ -95,30 +79,19 @@ class Plugin:
                 ['whoami'], encoding='utf-8').strip()
             logger.debug(f"whoami returned {user}")
             return user
-        except Exception as e:
+        except Exception:
             logger.error("whoami failed", exc_info=True)
             return None
 
     @staticmethod
-    def _getInstalledFlatpakNames() -> List[str]:
+    async def _getInstalledFlatpaksWithUpdates() -> List[str]:
         try:
             result = subprocess.check_output(
-                ['flatpak', 'list', '--columns=name'], encoding='utf-8')
+                ['flatpak', 'remote-ls', '--updates', '--columns=name,ref'], encoding='utf-8')
             return result.splitlines()
         except subprocess.CalledProcessError:
             logger.error(
-                f"execution of flatpak failed", exc_info=True)
-            return []
-
-    @staticmethod
-    def _getInstalledFlatpakRefs() -> List[str]:
-        try:
-            result = subprocess.check_output(
-                ['flatpak', 'list', '--columns=ref'], encoding='utf-8')
-            return result.splitlines()
-        except subprocess.CalledProcessError:
-            logger.error(
-                f"execution of flatpak failed", exc_info=True)
+                '_getInstalledFlatpaksWithUpdates() failed', exc_info=True)
             return []
 
     @staticmethod
@@ -126,37 +99,10 @@ class Plugin:
         logger.info(f'Updating {appID}...')
         try:
             result = subprocess.check_output(
-                ['flatpak', 'update', '--noninteractive', appID], encoding='utf-8')
+                ['flatpak', 'update', '--no-deploy', '--noninteractive', appID], encoding='utf-8')
             logger.info(f'_updateFlatpak({appID}):\n{result}')
             return True
         except subprocess.CalledProcessError:
             logger.error(
-                f"execution of flatpak failed", exc_info=True)
+                f'Failed to update flatpak {appID}', exc_info=True)
             return False
-
-    @staticmethod
-    def _getFlatpakInfo(appID: str, name: str) -> Optional[FlatpakInfo]:
-        info: FlatpakInfo = FlatpakInfo(
-            name=name, appID=appID, localHash=None, remoteHash=None, remote=None, ref=None, updateAvailable=False)
-        try:
-            data = subprocess.check_output(
-                ['flatpak', 'info', '-o', '-c', '-r', appID], encoding='utf-8').strip().split()
-            info.ref = data[0]
-            info.remote = data[1]
-            info.localHash = data[2]
-        except:
-            logger.error(
-                f'failed to get commit info for {appID}', exc_info=True)
-            return None
-
-        try:
-            info.remoteHash = subprocess.check_output(
-                ['flatpak', 'remote-info', info.remote, info.ref, '-c'], encoding='utf-8', timeout=2.5).strip()
-        except subprocess.CalledProcessError:
-            logger.error(
-                f'failed to get remote commit info for {appID}', exc_info=True)
-            return None
-
-        info.updateAvailable = info.localHash != info.remoteHash
-
-        return info

--- a/src/FlatpakInfo.ts
+++ b/src/FlatpakInfo.ts
@@ -1,23 +1,13 @@
 export class FlatpakInfo {
     appID: string;
     name: string;
-    localHash: string;
-    remoteHash: string;
-    remote: string;
-    ref: string;
-    updateAvailable: boolean;
 
-    constructor(appID: string, name: string, localHash: string, remoteHash: string, remote: string, ref: string, updateAvailable: boolean) {
+    constructor(appID: string, name: string) {
         this.appID = appID;
         this.name = name;
-        this.localHash = localHash;
-        this.remoteHash = remoteHash;
-        this.remote = remote;
-        this.ref = ref;
-        this.updateAvailable = updateAvailable;
     }
 
     static fromJSON(json: any) {
-        return new FlatpakInfo(json.appID, json.name, json.localHash, json.remoteHash, json.remote, json.ref, json.updateAvailable);
+        return new FlatpakInfo(json.appID, json.name);
     }
 }


### PR DESCRIPTION
This diff simplifies the data being passed to
just the name and appID(ref) as well as only
makes one call to `flatpak remote-ls` to get
all updatable flatpaks